### PR TITLE
Fast forward ticks and Enable better routing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ use std::sync::Arc;
 
 use std::thread;
 
-const N_THREADS: usize = 8;
+const N_THREADS: usize = 10_000;
 
 fn main() {
     let server = Arc::new(Server::default());

--- a/src/simulation/client.rs
+++ b/src/simulation/client.rs
@@ -52,11 +52,17 @@ impl Client {
         self.id = id;
     }
 
+    #[inline]
+    pub fn id(&self) -> usize {
+        self.id
+    }
+
     pub fn set_start(&mut self, tick: usize) {
         self.start = tick;
         self.abandon_tick = self.start + 20 * TICKS_PER_SECOND;
     }
 
+    #[inline]
     pub fn start(&self) -> usize {
         self.start
     }
@@ -66,14 +72,22 @@ impl Client {
         self.required_attributes.push(attr.clone());
     }
 
+    #[inline]
+    pub fn required_attributes(&self) -> &Vec<Attribute> {
+        &self.required_attributes
+    }
+
+    #[inline]
     pub fn is_unanswered(&self) -> bool {
         Status::Unanswered == self.status
     }
 
+    #[inline]
     pub fn is_answered(&self) -> bool {
         Status::Answered == self.status
     }
 
+    #[inline]
     pub fn is_abandoned(&self) -> bool {
         Status::Abandoned == self.status
     }

--- a/src/simulation/mod.rs
+++ b/src/simulation/mod.rs
@@ -146,9 +146,18 @@ impl Simulation {
 
     /// Find which clients haven't been added to the queue yet.
     fn enqueue_clients(&mut self) {
-        while let Some(client) = self.client_buffer.peek() && (client.0.borrow()).start() <= self.tick {
-            let next_client = self.client_buffer.pop().expect("Client was peeked and should have been popped").0;
-            
+        while self
+            .client_buffer
+            .peek()
+            .map_or(self.tick_until, |c| c.0.borrow().start())
+            <= self.tick
+        {
+            let next_client = self
+                .client_buffer
+                .pop()
+                .expect("Client was peeked and should have been popped")
+                .0;
+
             next_client.borrow_mut().enqueue(self.tick);
 
             self.client_queue.push(next_client);
@@ -156,8 +165,17 @@ impl Simulation {
     }
 
     fn enqueue_servers(&mut self) {
-        while let Some(server) = self.server_buffer.peek() && server.0.tick <= self.tick {
-            let next_server = self.server_buffer.pop().expect("Server was peeked and should have popped").0;
+        while self
+            .server_buffer
+            .peek()
+            .map_or(self.tick_until, |s| s.0.tick)
+            <= self.tick
+        {
+            let next_server = self
+                .server_buffer
+                .pop()
+                .expect("Server was peeked and should have popped")
+                .0;
 
             self.server_queue.push(next_server.server);
         }

--- a/src/simulation/routing.rs
+++ b/src/simulation/routing.rs
@@ -1,18 +1,38 @@
-use super::{Client, Server};
+use super::{Attribute, Client, Server};
 
 use std::cell::RefCell;
+use std::rc::Rc;
 use std::sync::Arc;
 
-// TODO: Support rlua? (allow custom lua scripts to execute and return routes)
-pub fn route_client(client: &RefCell<Client>, servers: &[Arc<Server>]) -> Option<Arc<Server>> {
-    let _ = client;
-    servers.first().map(Clone::clone)
+pub struct ClientRoutingData {
+    id: usize,
+    start: usize,
+    required_attributes: Vec<Attribute>,
 }
 
-// `route_client` should eventually support user provided routing. If/when that happens, then we
-// need to ensure that the route is validated. A false result should result in a "BadRoute" or
-// equiviliant `Client` Status.
-#[allow(dead_code)]
-pub fn validate_route(_client: &RefCell<Client>, _server: &Arc<Server>) -> bool {
-    true
+impl From<&Rc<RefCell<Client>>> for ClientRoutingData {
+    fn from(client: &Rc<RefCell<Client>>) -> Self {
+        let client = client.borrow();
+        Self {
+            id: client.id(),
+            start: client.start(),
+            required_attributes: client.required_attributes().clone(),
+        }
+    }
+}
+
+// TODO: Support rlua? (allow custom lua scripts to execute and return routes)
+pub fn route_clients(
+    clients: &Vec<ClientRoutingData>,
+    mut servers: Vec<&Arc<Server>>,
+) -> Vec<(usize, usize)> {
+    let mut routes = vec![];
+
+    for client in clients {
+        if let Some(server) = servers.pop() {
+            routes.push((client.id, server.id()));
+        }
+    }
+
+    routes
 }

--- a/src/simulation/server.rs
+++ b/src/simulation/server.rs
@@ -1,11 +1,29 @@
 use super::Attribute;
 use std::cmp::Ordering;
-use std::sync::Arc;
+use std::sync::{atomic, atomic::AtomicUsize, Arc};
+
+static ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 #[allow(dead_code)]
-#[derive(Debug, Default, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Server {
+    id: usize,
     attributes: Vec<Attribute>,
+}
+
+impl Default for Server {
+    fn default() -> Self {
+        Self {
+            id: ID_COUNTER.fetch_add(1, atomic::Ordering::SeqCst),
+            attributes: vec![],
+        }
+    }
+}
+
+impl Server {
+    pub fn id(&self) -> usize {
+        self.id
+    }
 }
 
 #[allow(clippy::module_name_repetitions)]


### PR DESCRIPTION
In many cases, the simulation was just ticking for the sake of ticking, even though the client and server buffer heads had enough information to directly advance. This PR fixes that. The one edge case is during routing. The future desires are to use rlua to enable custom implementations directly from user generated/created lua, as such the router needs to be called for every single tick to enable this customization.