### PR TITLE
Adding tests to Client finally

### DIFF
--- a/src/simulation/client.rs
+++ b/src/simulation/client.rs
@@ -1,6 +1,6 @@
 use super::{Attribute, ClientProfile, TICKS_PER_SECOND};
 use std::cmp::Ordering;
-use std::sync::Arc;
+use std::sync::{atomic, atomic::AtomicUsize, Arc};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Status {
@@ -15,7 +15,9 @@ impl Default for Status {
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+static ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Client {
     id: usize,
     required_attributes: Vec<Attribute>,
@@ -24,6 +26,20 @@ pub struct Client {
     established: Option<usize>,
     end: Option<usize>,
     status: Status,
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Self {
+            id: ID_COUNTER.fetch_add(1, atomic::Ordering::SeqCst),
+            required_attributes: vec![],
+            start: 0,
+            abandon_tick: 0,
+            established: None,
+            end: None,
+            status: Status::default(),
+        }
+    }
 }
 
 impl Ord for Client {
@@ -48,10 +64,6 @@ impl From<&Arc<ClientProfile>> for Client {
 }
 
 impl Client {
-    pub fn set_id(&mut self, id: usize) {
-        self.id = id;
-    }
-
     #[inline]
     pub fn id(&self) -> usize {
         self.id

--- a/src/simulation/client.rs
+++ b/src/simulation/client.rs
@@ -135,7 +135,15 @@ impl Client {
     }
 
     pub fn handle(&mut self, tick: usize, handling_time: usize) -> usize {
+        assert!(
+            tick >= self.start,
+            "Cannot tick in the past. started: {}, current: {}",
+            self.start,
+            tick
+        );
+
         println!("[CLIENT] {} handled at {}", self.id, tick);
+
         self.established = Some(tick);
         let end = tick + handling_time;
         self.end = Some(end);

--- a/src/simulation/client.rs
+++ b/src/simulation/client.rs
@@ -2,6 +2,8 @@ use super::{Attribute, ClientProfile, TICKS_PER_SECOND};
 use std::cmp::Ordering;
 use std::sync::{atomic, atomic::AtomicUsize, Arc};
 
+const ABANDON_TICKS: usize = 20 * TICKS_PER_SECOND;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Status {
     Unanswered,
@@ -69,9 +71,10 @@ impl Client {
         self.id
     }
 
-    pub fn set_start(&mut self, tick: usize) {
+    pub fn set_start(&mut self, tick: usize) -> usize {
         self.start = tick;
-        self.abandon_tick = self.start + 20 * TICKS_PER_SECOND;
+        self.abandon_tick = self.start + ABANDON_TICKS;
+        self.abandon_tick
     }
 
     #[inline]
@@ -121,7 +124,7 @@ impl Client {
             tick
         );
 
-        if self.abandon_tick < tick {
+        if self.abandon_tick <= tick {
             println!("[CLIENT] {} abandoned at {}", self.id, tick);
             self.status = Status::Abandoned;
             self.end = Some(tick);

--- a/src/simulation/mod.rs
+++ b/src/simulation/mod.rs
@@ -109,12 +109,10 @@ impl Simulation {
         self.clients = self
             .client_profiles
             .iter()
-            .enumerate()
-            .flat_map(|(i, cp)| {
+            .flat_map(|cp| {
                 let mut clients = vec![];
                 for _ in 0..cp.quantity {
                     let mut client = Client::from(cp);
-                    client.set_id(i);
 
                     let start = self.rng.gen_range(0..=self.tick_until);
                     client.set_start(start);


### PR DESCRIPTION
This also adds the ability to get `wait_time` and `handle` time from the Client. This will be used later for statistics, but is also good for validation of internal ticking mechanisms.